### PR TITLE
fix wdb on gevent/eventlet on PY2

### DIFF
--- a/wdb/__init__.py
+++ b/wdb/__init__.py
@@ -29,12 +29,12 @@ from .utils import pretty_frame
 from .state import Running, Step, Next, Until, Return
 from contextlib import contextmanager
 from log_colorizer import get_color_logger
-from multiprocessing.connection import Client
 from uuid import uuid4
 import dis
 import os
 import logging
 import sys
+import struct
 import threading
 import socket
 import webbrowser
@@ -63,6 +63,48 @@ for log_name in ('main', 'trace', 'ui', 'ext', 'bp'):
         os.getenv('WDB_LOG', 'WARNING')).upper()
     logging.getLogger(logger).setLevel(getattr(logging, level, 'WARNING'))
 
+class Client(object):
+    """A Client compatible with multiprocessing.connection.Client, that
+    uses socket objects."""
+    # https://github.com/akheron/cpython/blob/3.3/Lib/multiprocessing/connection.py#L349
+    def __init__(self, address):
+        self._handle = socket.socket()
+        self._handle.connect(address)
+        self._handle.setblocking(1)
+
+    def send_bytes(self, buf):
+        self._check_closed()
+        n = len(buf)
+        # For wire compatibility with 3.2 and lower
+        header = struct.pack("!i", n)
+        if n > 16384:
+            # The payload is large so Nagle's algorithm won't be triggered
+            # and we'd better avoid the cost of concatenation.
+            chunks = [header, buf]
+        elif n > 0:
+            # Issue # 20540: concatenate before sending, to avoid delays due
+            # to Nagle's algorithm on a TCP socket.
+            chunks = [header + buf]
+        else:
+            # This code path is necessary to avoid "broken pipe" errors
+            # when sending a 0-length buffer if the other end closed the pipe.
+            chunks = [header]
+        for chunk in chunks:
+            self._handle.sendall(chunk)
+
+    def recv_bytes(self):
+        self._check_closed()
+        size, = struct.unpack("!i", self._handle.recv(4))
+        return self._handle.recv(size)
+
+    def _check_closed(self):
+        if self._handle is None:
+            raise IOError("handle is closed")
+
+    def close(self):
+        self._check_closed()
+        self._handle.close()
+        self._handle = None
 
 class Wdb(object):
     """Wdb debugger main class"""
@@ -161,6 +203,7 @@ class Wdb(object):
                     'You must start wdb.server. '
                     '(Retrying on %s:%d) [Try #%d]' % (
                         SOCKET_SERVER, SOCKET_PORT, tries))
+                self._socket = None
 
         if not self._socket:
             log.error('Could not connect to server')

--- a/wdb/ext.py
+++ b/wdb/ext.py
@@ -50,12 +50,16 @@ class WdbMiddleware(object):
             return to_bytes('Wdb is now on'),
 
         if path == '/__wdb/shell':
-            # Enable wdb
-            Wdb.enabled = True
-            wdb = set_trace()
-            start_response('200 OK', [('Content-Type', 'text/html')])
-            wdb.die()
-            return to_bytes('Exited'),
+            def f():
+                # Enable wdb
+                Wdb.enabled = True
+                wdb = Wdb.get()
+                start_response('200 OK', [('Content-Type', 'text/html'), ('X-Thing', wdb.uuid)])
+                yield to_bytes(' '*4096)
+                wdb = set_trace()
+                wdb.die()
+                yield to_bytes('Exited')
+            return f()
 
         if Wdb.enabled:
             def trace_wsgi(environ, start_response):


### PR DESCRIPTION
Here's a test case:

``` python
import gevent
import gevent.monkey
gevent.monkey.patch_all()
import wsgiref.simple_server
import wdb.ext
wsgiref.simple_server.make_server('127.0.0.1', 8300, wdb.ext.WdbMiddleware(wsgiref.simple_server.demo_app)).serve_forever()
```

To test, run wdb.server.py in the background and also run this with WDB_NO_BROWSER_AUTO_OPEN=1 and visit http://localhost:8300/__wdb/shell.

With gevent>=1.0 on Python 2 it will spew errors, but with this patch (that uses `socket.socket` which is monkey-patched to `gevent.socket.socket`) it works perfectly.
