### PR TITLE
Add support for running in docker

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3
+RUN ["pip", "install", "wdb.server"]
+EXPOSE 19840
+EXPOSE 1984
+CMD ["wdb.server.py", "--detached_session"]


### PR DESCRIPTION
I have added support in the documentation for how to run wdb for an app running in a docker container. I have also added a `Dockerfile` to the server, so that you can set up Automated Docker builds, for the repository.

For it to create a docker build of the server, on every git push, you would need to set up an account on the docker registry and [add this repo to build](https://registry.hub.docker.com/builds/github/Kozea/wdb/) `Kozea/wdb-server`. 

It should pull from the master branch, with a Dockerfile location in `/server`.

How does that sound?