### PR TITLE
Handle uncommon python path installations

### DIFF
--- a/server/wdb_server/__init__.py
+++ b/server/wdb_server/__init__.py
@@ -20,6 +20,7 @@ import tornado.process
 import tornado.web
 import tornado.websocket
 import os
+import sys
 import logging
 import json
 from wdb_server.state import (
@@ -246,6 +247,9 @@ tornado.options.define("socket_port", default=19840,
                        help="Port used to communicate with wdb instances")
 tornado.options.define("server_port", default=1984,
                        help="Port used to serve debugging pages")
+tornado.options.define("extra_search_path", default=False,
+                       help=("Try harder to find the 'libpython*' shared library "
+                             "at the cost of a slower server startup."))
 
 tornado.options.parse_command_line()
 from wdb_server.utils import refresh_process, LibPythonWatcher
@@ -258,7 +262,8 @@ for l in (log, logging.getLogger('tornado.access'),
     l.setLevel(10 if tornado.options.options.debug else 30)
 
 if LibPythonWatcher:
-    LibPythonWatcher()
+    LibPythonWatcher(
+        sys.base_prefix if tornado.options.options.extra_search_path else None)
 
 server = tornado.web.Application(
     [

--- a/server/wdb_server/utils.py
+++ b/server/wdb_server/utils.py
@@ -37,16 +37,17 @@ except ImportError:
     LibPythonWatcher = None
 else:
     class LibPythonWatcher(object):
-        def __init__(self):
+        def __init__(self, extra_search_path=None):
             inotify = pyinotify.WatchManager()
             self.files = glob('/usr/lib/libpython*')
             if not self.files:
                 self.files = glob('/lib/libpython*')
 
-            # Handle custom installation paths
-            for root, dirnames, filenames in os.walk(sys.base_prefix):
-                for filename in fnmatch.filter(filenames, 'libpython*'):
-                    self.files.append(os.path.join(root, filename))
+            if extra_search_path is not None:
+                # Handle custom installation paths
+                for root, dirnames, filenames in os.walk(extra_search_path):
+                    for filename in fnmatch.filter(filenames, 'libpython*'):
+                        self.files.append(os.path.join(root, filename))
 
             log.debug('Watching for %s' % self.files)
             self.notifier = pyinotify.TornadoAsyncNotifier(

--- a/server/wdb_server/utils.py
+++ b/server/wdb_server/utils.py
@@ -15,6 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import sys
+import fnmatch
 from logging import getLogger
 from wdb_server.state import syncwebsockets
 from glob import glob
@@ -39,6 +42,11 @@ else:
             self.files = glob('/usr/lib/libpython*')
             if not self.files:
                 self.files = glob('/lib/libpython*')
+
+            # Handle custom installation paths
+            for root, dirnames, filenames in os.walk(sys.base_prefix):
+                for filename in fnmatch.filter(filenames, 'libpython*'):
+                    self.files.append(os.path.join(root, filename))
 
             log.debug('Watching for %s' % self.files)
             self.notifier = pyinotify.TornadoAsyncNotifier(


### PR DESCRIPTION
With this change, the first two `libpython*` detection routines can probably be removed, though, in that case, only processes running off the custom path will be handled.