### PR TITLE
catch ZombieProcess and AccessDenied exceptions while refresh processes

### DIFF
--- a/server/wdb_server/utils.py
+++ b/server/wdb_server/utils.py
@@ -75,9 +75,14 @@ def refresh_process(uuid=None):
     remaining_pids = []
     remaining_tids = []
     for proc in psutil.process_iter():
-        cl = proc.cmdline()
-        if len(cl) == 0:
+        try:
+            cl = proc.cmdline()
+        except (psutil.ZombieProcess, psutil.AccessDenied):
             continue
+        else:
+            if len(cl) == 0:
+                continue
+
         binary = cl[0].split('/')[-1]
         if (
                 ('python' in binary or 'pypy' in binary) and
@@ -107,5 +112,6 @@ def refresh_process(uuid=None):
             except Exception:
                 log.warn('', exc_info=True)
                 continue
+
     send('KeepProcess', remaining_pids)
     send('KeepThreads', remaining_tids)


### PR DESCRIPTION
I've got the same issue as https://github.com/Kozea/wdb/issues/35 , that is, the server UI keeps shaking, I've took a video: https://www.youtube.com/watch?v=ZYIJb6VT7BI

After some digging, I found the source of the issue is in `refresh_process`, when looping through processes with `refresh_process`, some process might raise `psutil.ZombieProcess, psutil.AccessDenied` exceptions, which breaks the websocket connection.