### PR TITLE
[msys] python2 from mingw32 doesn't have _winapi

### DIFF
--- a/client/wdb/_compat.py
+++ b/client/wdb/_compat.py
@@ -130,7 +130,14 @@ if python_version == 2:
     import time
     import select
 
-    if sys.platform == 'win32':
+    has_winapi = False
+    try:
+        import _winapi
+        has_winapi = True
+    except:
+        pass
+
+    if sys.platform == 'win32' and has_winapi:
         from _winapi import WAIT_OBJECT_0, WAIT_TIMEOUT, INFINITE
         import _winapi
         try:


### PR DESCRIPTION
For some reason the package _winapi is not provided by
mingw32/mingw-w64-i686-python2 2.7.11-4, so we need to check if this
package is available instead of assuming it's there.