### PR TITLE
Dont fail out when ran under say a C-based WSGIHandler

### DIFF
--- a/client/wdb/__init__.py
+++ b/client/wdb/__init__.py
@@ -265,7 +265,7 @@ class Wdb(object):
             stop_frame = None
             iframe = frame
             while iframe is not None:
-                if iframe.f_code == self.under.__code__:
+                if iframe.f_code == getattr(self.under, '__code__', None):
                     stop_frame = iframe
                 iframe = iframe.f_back
         iframe = frame


### PR DESCRIPTION
`WSGIHandler` may not have `__code__` as an attribute due to semi-normal reasons, this just avoids an `AttributeError`. Ty!