### PR TITLE
pinpoint dependency: tornado<5.0.0 to prevent incompatibilities

### DIFF
--- a/server/setup.py
+++ b/server/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 __version__ = '3.1.9'
 
 requires = [
-    "wdb==%s" % __version__, "tornado>=4.2", "psutil>=2.1", 'tornado_systemd'
+    "wdb==%s" % __version__, "tornado>=4.2, <5.0", "psutil>=2.1", 'tornado_systemd'
 ]
 if sys.platform == 'linux':
     requires.append('pyinotify')


### PR DESCRIPTION
in order to prevent this error::

   TypeError: add_accept_handler() takes 2 positional arguments but 3 were given

in tornado==5.0.0 the ioloop parameter was removed:

   add_accept_handler(sck, handle_connection, ioloop)