### PR TITLE
Made websockets work over HTTPS in home and better release Docker image

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -18,6 +18,8 @@ pushd client
 python setup.py sdist upload
 popd
 
+sed -i '' s/$OLD_VERSION/$NEW_VERSION/g server/Dockerfile
+
 git commit -am "Bump Version $OLD_VERSION -> $NEW_VERSION"
 git tag $NEW_VERSION
 git push

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3
-RUN ["pip", "install", "wdb.server"]
+
+ARG WDB_VERSION "3.2.3"
+
+RUN ["pip", "install", "wdb.server==$WDB_VERSION"]
 EXPOSE 19840
 EXPOSE 1984
 CMD ["wdb.server.py", "--detached_session"]

--- a/server/coffees/home.coffee
+++ b/server/coffees/home.coffee
@@ -221,7 +221,8 @@ ws_message = (event) ->
       ), 2000
 
 create_socket = ->
-  ws = new WebSocket "ws://#{location.host}/status"
+  proto = if (document.location.protocol == "https:") then "wss:" else "ws:"
+  ws = new WebSocket "{proto}//#{location.host}/status"
   ws.onopen = ->
     $("tbody tr").remove()
     ws.send('ListSockets')


### PR DESCRIPTION
* Fix websockets in home (missing from #113)
* Pin version installed in Dockerfile
* Change the pinned version on release