### PR TITLE
Correctly interpolate arguments in Dockerfile

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3
 
-ARG WDB_VERSION "3.2.3"
+ARG WDB_VERSION="3.2.3"
 
-RUN ["pip", "install", "wdb.server==$WDB_VERSION"]
+RUN pip install wdb.server==$WDB_VERSION
 EXPOSE 19840
 EXPOSE 1984
 CMD ["wdb.server.py", "--detached_session"]


### PR DESCRIPTION
This should fix failing Docker builds in DockerHub