### PR TITLE
Fix slight typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ like this:
 1. Start `wdb.server.py ` running in a container and expose port `1984` to your
    host computer, this will server the debugging web server.
 2. Start debugging in your app container, making sure to set `WDB_SOCKET_SERVER`
-   to the address of the server container, and point it to the expoed port
+   to the address of the server container, and point it to the exposed port
    `19840` on that server.
 3. When a trace is reached, open up `http://<your-docker-hostname>:1984`
 


### PR DESCRIPTION
Fixed a slight typo I noticed while reading readme.

Also, is `19840` a typo as well? Seems like the majority of times the port referenced is `1984`, although I do see both ports are exposed in the dockerfile... Just seems kind of inconsistent since on point 2 (line 263) it mentions `19840` but on the point right after, the address uses `1984`. Let me know if I should change this here as well :)