### PR TITLE
Compatible json with python < 3.5

### DIFF
--- a/client/wdb/_compat.py
+++ b/client/wdb/_compat.py
@@ -5,7 +5,11 @@ import sys
 python_version = sys.version_info[0]
 
 try:
-    from json import loads, dumps, JSONEncoder, JSONDecodeError
+    from json import loads, dumps, JSONEncoder
+    try:
+        from json import JSONDecodeError
+    except ImportError:
+        JSONDecodeError = ValueError  # python < 3.5
 except ImportError:
     from simplejson import loads, dumps, JSONEncoder, JSONDecodeError
 


### PR DESCRIPTION
As you can see in https://docs.python.org/3/library/json.html#json.JSONDecodeError this exception was added in Python 3.5.

Having to require `simplejson` just for the exception seems a bit too much for the job. It's easier to handle that `ImportError` separately and still allow the native `json` module to work.