### PR TITLE
Remove py2 from travis and tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 
 language: python
 python:
-  - 2.7
   - 3.6
   - 3.7
   - nightly

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py32, py33, py34, pypy
 setupdir = client
 
 [testenv]


### PR DESCRIPTION
Hi! I'm dropping the support to py2, but I would like to help and contribute with this repository.  
